### PR TITLE
Fixed a bug where get_user_home_dir() would not be found on Linux

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use crate::vorutils::get_user_home_dir;
 use crate::{
     vorerr::VORAppError,
     vorutils::{file_exists, path_exists}, pf::PacketFilter,
@@ -6,7 +8,6 @@ use core::fmt;
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use crate::vorutils::get_user_home_dir;
 
 #[derive(Clone)]
 pub struct VORConfigWrapper {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use core::fmt;
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 use std::fs;
+use crate::vorutils::get_user_home_dir;
 
 #[derive(Clone)]
 pub struct VORConfigWrapper {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,7 @@
 use crate::config::vor_root;
 use crate::pf::PacketFilter;
 use crate::routedbg::DebugPacket;
+use crate::vorutils::get_user_home_dir;
 use crate::VCArgs;
 use crate::{
     config::{

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,8 @@
+#[cfg(target_os = "linux")]
+use crate::vorutils::get_user_home_dir;
 use crate::config::vor_root;
 use crate::pf::PacketFilter;
 use crate::routedbg::DebugPacket;
-use crate::vorutils::get_user_home_dir;
 use crate::VCArgs;
 use crate::{
     config::{


### PR DESCRIPTION
Using Debian 12.2. Looks like the inclusion of the `use crate::vorutils::get_user_home_dir;` header in `ui.rs` and `config.rs` took care of things for me, hope this helps anyone else!